### PR TITLE
feat: add link to error log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8854,6 +8854,22 @@
         "has-flag": "^3.0.0"
       }
     },
+    "supports-hyperlinks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+      "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
+      "requires": {
+        "has-flag": "^2.0.0",
+        "supports-color": "^5.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        }
+      }
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -8898,6 +8914,15 @@
         "pify": "^3.0.0",
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
+      }
+    },
+    "terminal-link": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-1.3.0.tgz",
+      "integrity": "sha512-nFaWG/gs3brGi3opgWU2+dyFGbQ7tueSRYOBOD8URdDXCbAGqDEZzuskCc+okCClYcJFDPwn8e2mbv4FqAnWFA==",
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "supports-hyperlinks": "^1.0.1"
       }
     },
     "test-exclude": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "log-update": "^3.2.0",
     "redux": "^4.0.1",
     "string-width": "^4.1.0",
+    "terminal-link": "^1.3.0",
     "tmp": "^0.1.0",
     "wrap-ansi": "^6.0.0",
     "yargs": "^13.0.0-candidate.0"

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,6 +1,7 @@
 import { EOL } from "os";
 import { Store } from "redux";
 import logUpdate from "log-update";
+import terminalLink from 'terminal-link'
 import stringWidth from "string-width";
 import chalk from "chalk";
 import { headWordWrap } from "./lib/ansi";
@@ -54,7 +55,8 @@ function renderStatus({
 }
 
 function renderLogPath({ error, logPath }: SubState): string {
-  return error ? `(saved to ${logPath})` : "";
+  const link = terminalLink.isSupported ? terminalLink(logPath, `file://${logPath}`) : logPath;
+  return error ? `(saved to ${link})` : "";
 }
 
 function renderError({ error }: SubState): string {


### PR DESCRIPTION
Reference: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
Uses: https://github.com/sindresorhus/terminal-link

## Supported terminal (iTerm2)

<img width="810" alt="Screen Shot 2019-08-03 at 19 59 59" src="https://user-images.githubusercontent.com/1424963/62411058-58b9d980-b629-11e9-9691-34450bdd7ec4.png">

## Unsupported terminal (Hyper)

![Screen Shot 2019-08-03 at 19 59 42](https://user-images.githubusercontent.com/1424963/62411071-61aaab00-b629-11e9-92c4-62ca89c891b9.png)
