### PR TITLE
feat: interactive rebuild prompt

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -10,6 +10,7 @@ import { reducer } from "../store/reducer";
 import * as actions from "../store/action";
 import { Compiler } from "../compiler";
 import { Tester } from "../tester";
+import { registerKeypress } from '../registerKeypress';
 
 type Options = {
   buildScript: string;
@@ -36,6 +37,9 @@ async function getStore(rootDir: string, options: Options) {
         width: tty.columns!,
         height: tty.rows!
       },
+      cursor: {
+        position: 0
+      },
       packages: {}
     }
   );
@@ -59,6 +63,7 @@ export async function main(cwd: string, options: Options) {
 
   const store = await getStore(rootDir, options);
   store.subscribe(createRenderer(store));
+  registerKeypress({ store })
 
   const packages = getPackages(store.getState());
   if (packages.length === 0) {

--- a/src/registerKeypress.ts
+++ b/src/registerKeypress.ts
@@ -1,0 +1,26 @@
+import readline from 'readline'
+import { Store } from 'redux'
+import { State } from './store/state'
+import { Action } from './store/action'
+import * as actions from './store/action'
+
+readline.emitKeypressEvents(process.stdin)
+
+export const registerKeypress = ({
+  store,
+}: {
+  store: Store<State, Action>
+}) => {
+  if (process.stdin.setRawMode) {
+    process.stdin.setRawMode(true)
+  }
+
+  process.stdin.on('keypress', (chunk, key) => {
+    // RawMode own kill switch
+    if (key.sequence === '\u0003') {
+      process.exit()
+    }
+
+    store.dispatch(actions.onKeypress(chunk, key))
+  })
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,7 +1,7 @@
 import { EOL } from "os";
 import { Store } from "redux";
 import logUpdate from "log-update";
-import terminalLink from 'terminal-link'
+import terminalLink from "terminal-link";
 import stringWidth from "string-width";
 import chalk from "chalk";
 import { headWordWrap } from "./lib/ansi";
@@ -23,14 +23,14 @@ function renderCursor({
   ready,
   buildBusy,
   testBusy,
-  error,
+  error
 }: SubState & {
-  indicator: string
-  cursor: number
-  index: number
+  indicator: string;
+  cursor: number;
+  index: number;
 }): string {
   if (cursor !== index) {
-    return ' '
+    return " ";
   }
   if (error) {
     return chalk.red(indicator);
@@ -49,8 +49,12 @@ function renderIndicator({
   ready,
   buildBusy,
   testBusy,
-  error
+  error,
+  selected
 }: SubState & { indicator: string }): string {
+  if (selected) {
+    return chalk.yellow(indicator);
+  }
   if (error) {
     return chalk.red(indicator);
   }
@@ -84,7 +88,9 @@ function renderStatus({
 }
 
 function renderLogPath({ error, logPath }: SubState): string {
-  const link = terminalLink.isSupported ? terminalLink(logPath, `file://${logPath}`) : logPath;
+  const link = terminalLink.isSupported
+    ? terminalLink(logPath, `file://${logPath}`)
+    : logPath;
   return error ? `(saved to ${link})` : "";
 }
 
@@ -132,8 +138,11 @@ export function render(props: Props): string {
 
   const lines = packages
     .map((subState, index) => ({
-      cursor: renderCursor({...subState, indicator: "❯" , cursor, index }),
-      indicator: renderIndicator({ ...subState, indicator: "●" }),
+      cursor: renderCursor({ ...subState, indicator: "❯", cursor, index }),
+      indicator: renderIndicator({
+        ...subState,
+        indicator: subState.selected ? "■" : "●"
+      }),
       status: renderStatus(subState),
       logPath: renderLogPath(subState)
     }))

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -16,6 +16,18 @@ type Props = {
   packages: SubState[];
 };
 
+function renderWelcomeMessages(): string[] {
+  const description = chalk.gray(
+    `⬢ Now watching the files, saving any file will rebuild the package.`
+  );
+  const question =
+    chalk.green(`? `) +
+    chalk.gray.italic(`interactive rebuild? `) +
+    chalk.gray.italic.underline(`(select=spacekey, run=return)`);
+  const breakline = ""
+  return [description, question, breakline]
+}
+
 function renderCursor({
   cursor,
   index,
@@ -150,14 +162,15 @@ export function render(props: Props): string {
       return `${cursor}${indicator} ${status} ${logPath}`;
     });
 
-  const restLines = height - lines.length;
+  const welcome = renderWelcomeMessages()
+  const restLines = height - (welcome.length + lines.length);
   const erroredPackages = packages.filter(({ error }) => !!error);
   const linesPerError = Math.floor(restLines / erroredPackages.length);
   const errorSummaries = erroredPackages.map(subState =>
     renderErrorSummary({ width, lines: linesPerError, ...subState })
   );
 
-  return lines.concat(errorSummaries).join(EOL);
+  return [...welcome,...lines,...errorSummaries].join(EOL);
 }
 
 export const createRenderer = (store: Store<State, Action>) => () => {

--- a/src/store/action.ts
+++ b/src/store/action.ts
@@ -55,6 +55,20 @@ export const setSize = ({
   height
 });
 
+export const onKeypress = (chunk:any, key:any) => ({
+  type: "ON_KEYPRESS" as const,
+  chunk,
+  key
+});
+
+export const moveUpCursor = () => ({
+  type: "CURSOR_MOVE_UP" as const,
+});
+
+export const moveDownCursor = () => ({
+  type: "CURSOR_MOVE_DOWN" as const,
+});
+
 export type Action =
   | ReturnType<typeof addPackage>
   | ReturnType<typeof makeReady>
@@ -64,4 +78,7 @@ export type Action =
   | ReturnType<typeof runTest>
   | ReturnType<typeof completeTest>
   | ReturnType<typeof enqueueTest>
-  | ReturnType<typeof setSize>;
+  | ReturnType<typeof setSize>
+  | ReturnType<typeof onKeypress>
+  | ReturnType<typeof moveUpCursor>
+  | ReturnType<typeof moveDownCursor>

--- a/src/store/action.ts
+++ b/src/store/action.ts
@@ -11,6 +11,11 @@ export const makeReady = (dir: string) => ({
   dir
 });
 
+export const toggleSelected = (dir: string) => ({
+  type: "TOGGLE_SELECTED" as const,
+  dir
+});
+
 export const startCompile = (dir: string) => ({
   type: "COMPILE_STARTED" as const,
   dir
@@ -72,6 +77,7 @@ export const moveDownCursor = () => ({
 export type Action =
   | ReturnType<typeof addPackage>
   | ReturnType<typeof makeReady>
+  | ReturnType<typeof toggleSelected>
   | ReturnType<typeof startCompile>
   | ReturnType<typeof completeCompile>
   | ReturnType<typeof enqueueCompile>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,6 +9,7 @@ import { createMiddleware as createTestMiddleware } from "./middleware/test";
 import { createMiddleware as createLogMiddleware } from "./middleware/log";
 import { createMiddleware as createResizeMiddleware } from "./middleware/resize";
 import { createMiddleware as createNotifyMiddleware } from "./middleware/notify";
+import { createMiddleware as createCursorMiddleware } from "./middleware/cursor";
 
 export function createStore(
   initialState: State,
@@ -29,6 +30,7 @@ export function createStore(
   const middlewares = [
     createNotifyMiddleware({ allowNotify }),
     createResizeMiddleware(tty),
+    createCursorMiddleware(),
     createCompileMiddleware(compiler, { runTests }),
     createTestMiddleware(tester),
     createLogMiddleware()

--- a/src/store/middleware/compile.ts
+++ b/src/store/middleware/compile.ts
@@ -5,6 +5,7 @@ import {
   startCompile,
   completeCompile,
   enqueueCompile,
+  toggleSelected,
   runTest
 } from "../action";
 import { Compiler } from "../../compiler";
@@ -20,7 +21,10 @@ export const createMiddleware = (
 ): Middleware<{}, State> => store => next => (action: Action) => {
   switch (action.type) {
     case "COMPILE_STARTED": {
-      const { buildBusy } = getPackageMap(store.getState())[action.dir];
+      const { buildBusy, selected } = getPackageMap(store.getState())[action.dir];
+      if (selected) {
+        store.dispatch(toggleSelected(action.dir));
+      }
       if (buildBusy) {
         store.dispatch(enqueueCompile(action.dir));
         return;

--- a/src/store/middleware/cursor.ts
+++ b/src/store/middleware/cursor.ts
@@ -1,0 +1,31 @@
+import { Middleware } from "redux";
+import { State } from "../state";
+import * as actions from "../action";
+import { Action } from "../action";
+import { getPackages } from "../../store/selectors";
+
+export const createMiddleware = (): Middleware<{}, State> => store => next => (
+  action: Action
+) => {
+  const state = store.getState()
+  const packages = getPackages(state)
+  const currentPosition = state.cursor.position
+  const isMinPosition = state.cursor.position === 0
+  const isMaxPosition = state.cursor.position === packages.length - 1
+
+  switch (action.type) {
+    case "ON_KEYPRESS": {
+      const seqence = action.key.sequence
+      // on up-key
+      if(!isMinPosition && action.key.sequence === '\u001b[A') store.dispatch(actions.moveUpCursor())
+      // on down-key
+      if(!isMaxPosition && action.key.sequence === '\u001b[B') store.dispatch(actions.moveDownCursor())
+      // on return-key
+      if(seqence === '\r') {
+        const pkg = packages[currentPosition].package
+        store.dispatch(actions.startCompile(pkg.location))
+      }
+    }
+  }
+  return next(action);
+};

--- a/src/store/middleware/cursor.ts
+++ b/src/store/middleware/cursor.ts
@@ -2,28 +2,38 @@ import { Middleware } from "redux";
 import { State } from "../state";
 import * as actions from "../action";
 import { Action } from "../action";
-import { getPackages } from "../../store/selectors";
+import { getPackages, getSelectedPackages } from "../../store/selectors";
 
 export const createMiddleware = (): Middleware<{}, State> => store => next => (
   action: Action
 ) => {
-  const state = store.getState()
-  const packages = getPackages(state)
-  const currentPosition = state.cursor.position
-  const isMinPosition = state.cursor.position === 0
-  const isMaxPosition = state.cursor.position === packages.length - 1
-
   switch (action.type) {
     case "ON_KEYPRESS": {
-      const seqence = action.key.sequence
+      const state = store.getState();
+      const packages = getPackages(state);
+      const currentPosition = state.cursor.position;
+      const focusPkg = packages[currentPosition].package;
+      const isMinPosition = state.cursor.position === 0;
+      const isMaxPosition = state.cursor.position === packages.length - 1;
+      const seqence = action.key.sequence;
+
       // on up-key
-      if(!isMinPosition && action.key.sequence === '\u001b[A') store.dispatch(actions.moveUpCursor())
+      if (!isMinPosition && action.key.sequence === "\u001b[A") {
+        store.dispatch(actions.moveUpCursor());
+      }
       // on down-key
-      if(!isMaxPosition && action.key.sequence === '\u001b[B') store.dispatch(actions.moveDownCursor())
+      if (!isMaxPosition && action.key.sequence === "\u001b[B") {
+        store.dispatch(actions.moveDownCursor());
+      }
       // on return-key
-      if(seqence === '\r') {
-        const pkg = packages[currentPosition].package
-        store.dispatch(actions.startCompile(pkg.location))
+      if (seqence === "\r") {
+        getSelectedPackages(state).forEach(({ package: selectedPkg }) =>
+          store.dispatch(actions.startCompile(selectedPkg.location))
+        );
+      }
+      // on space-key
+      if (seqence === " ") {
+        store.dispatch(actions.toggleSelected(focusPkg.location));
       }
     }
   }

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -7,6 +7,9 @@ const initialState: State = {
     width: -1,
     height: -1
   },
+  cursor: {
+    position: 0
+  },
   packages: {}
 };
 
@@ -54,6 +57,14 @@ function reduce(draft: Draft<State>, action: Action) {
     case "RESIZED": {
       draft.size.width = action.width;
       draft.size.height = action.height;
+      break;
+    }
+    case "CURSOR_MOVE_UP": {
+      draft.cursor.position -= 1
+      break;
+    }
+    case "CURSOR_MOVE_DOWN": {
+      draft.cursor.position += 1;
       break;
     }
   }

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -20,6 +20,7 @@ function reduce(draft: Draft<State>, action: Action) {
         package: action.pkg,
         logPath: action.logPath,
         ready: false,
+        selected: false,
         buildBusy: false,
         buildQueued: false,
         testBusy: false,
@@ -29,6 +30,9 @@ function reduce(draft: Draft<State>, action: Action) {
       break;
     case "MAKE_READY":
       draft.packages[action.dir].ready = true;
+      break;
+    case "TOGGLE_SELECTED":
+      draft.packages[action.dir].selected = !draft.packages[action.dir].selected;
       break;
     case "COMPILE_STARTED":
       draft.packages[action.dir].buildBusy = true;

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -13,4 +13,7 @@ export const getPackages = (state: State) =>
     subState => subState.package.name
   );
 
+export const getSelectedPackages = (state: State) =>
+  getPackages(state).filter(pkg => !!pkg.selected);
+
 export const getCursor = (state: State) => state.cursor.position;

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -12,3 +12,5 @@ export const getPackages = (state: State) =>
     Object.values(getPackageMap(state)),
     subState => subState.package.name
   );
+
+export const getCursor = (state: State) => state.cursor.position;

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -22,6 +22,9 @@ export type State = {
     width: number;
     height: number;
   };
+  cursor: {
+    position: number;
+  };
   packages: {
     [dir: string]: SubState;
   };

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -8,6 +8,7 @@ export type Package = {
 
 export type SubState = {
   ready: boolean;
+  selected: boolean;
   buildQueued: boolean;
   testQueued: boolean;
   buildBusy: boolean;


### PR DESCRIPTION
## New feature PR - interactive prompt

![2019-11-18 17-23-19 2019-11-18 17_33_11](https://user-images.githubusercontent.com/7282145/69036613-9cdeb780-0a29-11ea-8f54-52a98f8c4e80.gif)

### Advantage

- The `--scope` chain is unnecessary
  - No need to do annoying `lerna build --scoped packageA --scope packageB --scope packageC`
- When we want to rebuild an unopened package on editor
  - Case: build error occurred involving another package
