### PR TITLE
fix: output verbose child process error log

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -21,7 +21,7 @@ export class Compiler {
         cwd
       });
     } catch (e) {
-      throw new Error(`[exitCode:${e.exitCode}] ${e.stderr}`);
+      throw new Error(`[exitCode:${e.exitCode}] ${e.all}`);
     }
   }
 


### PR DESCRIPTION
Fix the problem that error log thrown inside the build is not output correctly (e.g. TypeScript compile error messages).

Output all error of thrown object by execa.
see: https://github.com/sindresorhus/execa/tree/e98561a71df16695f56700d7be406ec8fe41f0a3

By the way, the current dependent version of execa is v2, but from v3 enable the `all` option is required.