### PR TITLE
fix: enable execa `all` option

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -18,7 +18,8 @@ export class Compiler {
     }
     try {
       await execa("npm", ["run", this.scriptName], {
-        cwd
+        cwd,
+        all: true,
       });
     } catch (e) {
       throw new Error(`[exitCode:${e.exitCode}] ${e.all}`);


### PR DESCRIPTION
Related #40 . 

From execa v3, `all` option is changed to false by default. So enable it.