### PR TITLE
Support wrap lines

### DIFF
--- a/src/lib/ansi.test.ts
+++ b/src/lib/ansi.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { head, wordWrap } from "./ansi";
+import { head, wordWrap, countLines } from "./ansi";
 
 describe("head", () => {
   it("returns string that specified number of lines", () => {
@@ -13,6 +13,19 @@ describe("wordWrap", () => {
   it("returns string that wrapped at specified width", () => {
     const expected = "a".repeat(5) + "\na";
     const actual = wordWrap("a".repeat(6), 5);
+    assert.strictEqual(actual, expected);
+  });
+});
+
+describe("countLines", () => {
+  it("returns number of lines from the string", () => {
+    const expected = 6;
+    const actual = countLines("a\n".repeat(5));
+    assert.strictEqual(actual, expected);
+  });
+  it("case without EOL", () => {
+    const expected = 1;
+    const actual = countLines("a".repeat(5));
     assert.strictEqual(actual, expected);
   });
 });

--- a/src/lib/ansi.ts
+++ b/src/lib/ansi.ts
@@ -15,3 +15,7 @@ export function wordWrap(str: string, width: number): string {
 export function headWordWrap(str: string, width: number, height: number) {
   return head(wordWrap(str, width), height);
 }
+
+export function countLines(str: string) {
+  return (str.match(/\n/g) || "").length + 1;
+}


### PR DESCRIPTION
## Summary

**Support rendering multiple lines when characters wrap**

## Specific cases

Characters wrap in the following cases:

* For narrow terminals
* For long package names
* For long error log paths